### PR TITLE
Cloudwatch emf cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,3 +56,42 @@ I've only set this up once so take this with a grain of salt.
 * aws-embedded-metrics
   * It doesn't add many dependencies!
   * It causes warnings in unit tests and seems to slow them down - it's trying to open a socket to a number of ports on localhost, which I'm guessing is its way of streaming to Cloudwatch on EC2
+  * Default dimensions: LogGroup, ServiceName, ServiceType (an example is below)
+  * EMF logs are pretty verbose
+  * The default namespace is weird - I really want it to be the service name
+* How can we get the lambda's namespace _before_ the lambda handler? It's available from the context object but I want to log the model loading time and put it in a namespace akin to the function
+
+## Example EMF log
+
+```{
+    "LogGroup": "ExampleTextClassifierStac-ExampleTextClassifierHan-PZQ8yd6C6x3R",
+    "ServiceName": "ExampleTextClassifierStac-ExampleTextClassifierHan-PZQ8yd6C6x3R",
+    "ServiceType": "AWS::Lambda::Function",
+    "executionEnvironment": "AWS_Lambda_python3.8",
+    "memorySize": "3008",
+    "functionVersion": "$LATEST",
+    "logStreamId": "2021/10/16/[$LATEST]f35168a9ad9e40e39422fb6be26a5800",
+    "_aws": {
+        "Timestamp": 1634401767050,
+        "CloudWatchMetrics": [
+            {
+                "Dimensions": [
+                    [
+                        "LogGroup",
+                        "ServiceName",
+                        "ServiceType"
+                    ]
+                ],
+                "Metrics": [
+                    {
+                        "Name": "input.num_chars",
+                        "Unit": "Count"
+                    }
+                ],
+                "Namespace": "aws-embedded-metrics"
+            }
+        ]
+    },
+    "input.num_chars": 66
+}
+```

--- a/serving/app/app.py
+++ b/serving/app/app.py
@@ -9,6 +9,10 @@ from aws_embedded_metrics.config import get_config
 metrics_config = get_config()
 metrics_config.namespace = os.environ.get("AWS_LAMBDA_FUNCTION_NAME", metrics_config.namespace)
 
+# The specific env var isn't too important. What's important is that it'll be set on lambda, and local otherwise
+# This speeds up unit tests; otherwise it auto-detects and tries to connect to HTTP sockets
+metrics_config.environment = os.environ.get("AWS_EXECUTION_ENV", "local")
+
 
 @metric_scope
 def load_model(metrics: MetricsLogger):

--- a/serving/app/app.py
+++ b/serving/app/app.py
@@ -1,10 +1,28 @@
 import json
 import os.path
+import time
+
 import joblib
 from aws_embedded_metrics import metric_scope, MetricsLogger
+from aws_embedded_metrics.config import get_config
 
-model_path = os.path.join(os.path.dirname(__file__), "data/model.joblib.gz", )
-model = joblib.load(model_path)
+metrics_config = get_config()
+metrics_config.namespace = os.environ.get("AWS_LAMBDA_FUNCTION_NAME", metrics_config.namespace)
+
+
+@metric_scope
+def load_model(metrics: MetricsLogger):
+    start_time = time.time()
+    model_path = os.path.join(os.path.dirname(__file__), "data/model.joblib.gz", )
+    model = joblib.load(model_path)
+
+    duration_seconds = time.time() - start_time
+    metrics.put_metric("load_model.duration", duration_seconds, "Seconds")
+
+    return model
+
+
+model = load_model()
 
 
 @metric_scope


### PR DESCRIPTION
* Set a metrics namespace from the function name
* Fix logging for unit tests
* Start logging model loading time